### PR TITLE
fix: add missing else block in Countdown component for correct logic

### DIFF
--- a/src/components/ui/Countdown.astro
+++ b/src/components/ui/Countdown.astro
@@ -53,7 +53,7 @@ if (!isNaN(countDownDate) && countDownDate > Date.now()) {
 
       comingSoonText.classList.remove('is-hide')
       countersWrapper.classList.remove('is-show')
-
+    } else {
       const getDays = Math.floor(dateGap / (1000 * 60 * 60 * 24))
       const getHours = Math.floor(
         (dateGap % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)


### PR DESCRIPTION
This pull request includes a small change to the `src/components/ui/Countdown.astro` file. The change adds an `else` clause to handle the case when `countDownDate` is not a valid number or is not greater than the current date. 

* [`src/components/ui/Countdown.astro`](diffhunk://#diff-63d8062e55310d81f180a0246b099f619d6176c9ce49aee93a8906e2019e49deL56-R56): Added an `else` clause to handle invalid or past countdown dates.

Preview:

https://github.com/user-attachments/assets/9b241992-0efb-455c-81e0-ced21219135d

