### PR TITLE
fix: adjust styles in Slider component for responsive and fix body overflow (#60)

### DIFF
--- a/src/components/ui/Slider.astro
+++ b/src/components/ui/Slider.astro
@@ -42,16 +42,5 @@ const getImages = import.meta.glob<{ default: ImageMetadata }>(
     gap: 100px;
     width: 100%;
     margin: 48px auto;
-
-    & .embla {
-      padding: 0;
-      mask-image: linear-gradient(
-        90deg,
-        #0000 0%,
-        #000 30% 50%,
-        #000 70%,
-        #0000 100%
-      );
-    }
   }
 </style>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -57,6 +57,10 @@ const { title, description, metaRobots } = options;
         navigation: auto;
       }
 
+      body {
+        overflow-x: hidden;
+      }
+
       body::-webkit-scrollbar {
         width: 7px;
         height: 7px;

--- a/src/styles/slider.css
+++ b/src/styles/slider.css
@@ -10,8 +10,9 @@
   --number-of-slides: 2;
 
   max-width: 1146px;
+  width: 100%;
   margin: auto;
-  padding-inline: 16px;
+  padding-inline: 0px;
   mask-image: linear-gradient(90deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 20%, rgba(0, 0, 0, 1) 50%, rgba(0, 0, 0, 1) 80%, rgba(0, 0, 0, 0) 100%);
 
   .embla-viewport {


### PR DESCRIPTION
Este pull request soluciona #60 e incluye cambios en el estilo del componente `slider` y en el `base` layout. Los cambios más importantes incluyen la eliminación de estilos innecesarios del componente `slider`, el ajuste del `padding` y el ancho del `slider` y que el `body` no se desborde horizontalmente.

Cambios en el estilo del componente `slider`:

* [`src/components/ui/Slider.astro`](diffhunk://#diff-feecb2d2291def8ebc400e4700b3f45d19f8ec986c39cf3cff7d747faa870f9cL45-L55): Eliminados estilos innecesarios para la clase `.embla`.
* [`src/styles/slider.css`](diffhunk://#diff-4695f449d7d159cbdce0c6e0b406a7c442cb9404adf4e738e498ccf2226aba10R13-R15): Se ha ajustado la anchura al 100%, se ha eliminado el relleno en línea y se ha actualizado el degradado de la imagen de máscara.

Cambios en el `base` layout:

* [`src/layouts/Base.astro`](diffhunk://#diff-7f2bb650ebd4f62eed5e3c6f8b11553b541064b5a9ef01c815cb148e716090beR60-R63): Añadido `overflow-x: hidden` al `body` para evitar el desbordamiento horizontal.

Vista previa:

https://github.com/user-attachments/assets/1d2bf81b-e4e6-49e2-941a-03fd56adbfe4
