### PR TITLE
feat: add StaticCountdown component and replace Countdown in Parallax Section

### DIFF
--- a/src/components/ui/StaticCountdown.astro
+++ b/src/components/ui/StaticCountdown.astro
@@ -1,0 +1,55 @@
+<div class="countdown">
+  <p class="coming-soon">Octubre 2025</p>
+</div>
+
+<style>
+  .countdown {
+    width: 100%;
+    max-width: 586px;
+    height: auto;
+    max-height: 135px;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    margin: 0 auto;
+    border-radius: var(--rounded-md);
+    outline: 1px solid var(--stone-700);
+
+    color: var(--white);
+
+    background: rgba(12, 10, 9, 0.7);
+    box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+    backdrop-filter: blur(20px);
+
+    @media (width >= 1200px) {
+      max-width: 696px;
+    }
+
+    & .coming-soon {
+      font-family: "Inconsolata Variable", monospace;
+      font-size: 56px;
+      font-weight: 700;
+      color: var(--white);
+      text-align: center;
+      margin: 0;
+    }
+  }
+
+  @media (width <= 1024px) {
+    .coming-soon {
+      font-size: 48px;
+    }
+  }
+
+  @media (width <= 768px) {
+    .countdown {
+      width: 100%;
+
+      & .coming-soon {
+        font-size: 32px;
+      }
+    }
+  }
+</style>

--- a/src/pages/_index/CountdownSection.astro
+++ b/src/pages/_index/CountdownSection.astro
@@ -1,7 +1,0 @@
----
-import Countdow from '@components/ui/Countdown.astro'
----
-
-<section style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: '100vh' }}>
-  <Countdow />
-</section>

--- a/src/pages/_index/ParallaxSection.astro
+++ b/src/pages/_index/ParallaxSection.astro
@@ -2,7 +2,7 @@
 import type { ImageMetadata } from 'astro'
 import parallaxImages from '@data/parallax-images'
 import ClickToScroll from '@ui/ClickToScroll.astro'
-import Countdown from '@ui/Countdown.astro'
+import StaticCountdown from '@ui/StaticCountdown.astro'
 import { Picture } from 'astro:assets'
 
 const getImages = import.meta.glob<{ default: ImageMetadata }>(
@@ -13,7 +13,7 @@ const getImages = import.meta.glob<{ default: ImageMetadata }>(
 <section class="parallax-container" id="cuenta-regresiva">
   <div class="information">
     <h2>La cuenta regresiva comenzará pronto</h2>
-    <Countdown />
+    <StaticCountdown />
   </div>
   <div class="layers">
     {


### PR DESCRIPTION
Este pull request introduce un nuevo componente `StaticCountdown` y reemplaza el actual componente dinámico de `Countdown`, debido a que la información ahora es estática y no necesita mostrar ningún temporizador de cuenta regresiva.

Los principales cambios son:

**Incorporación de un nuevo componente:**
* [`src/components/ui/StaticCountdown.astro`](diffhunk://#diff-377c7bca563fbcb11ac485e494e9c9d792159fd627aa0120d255bda198385702R1-R55): Añadido un nuevo `StaticCountdown` manteniendo los mismos estilos y diseño al componente `Countdown` actual.

**Actualizaciones de importación:**
* [`src/pages/_index/CountdownSection.astro`](diffhunk://#diff-ef9372b5e33d2498d435810e679fbad9ea2740b4664208558a5710b314bea4a5L1-L7): Eliminada la sección sin utilizar `CountdownSection.astro`.
* [`src/pages/_index/ParallaxSection.astro`](diffhunk://#diff-0371bbc79a2e6b24278803b057873e6350143fb86b0313373dbba39c024b2afbL5-R5): Actualizada la importación de `Countdown` a `StaticCountdown`.

**Actualización del uso del componente:**
* [`src/pages/_index/ParallaxSection.astro`](diffhunk://#diff-0371bbc79a2e6b24278803b057873e6350143fb86b0313373dbba39c024b2afbL16-R16): Sustituido el componente `Countdown` por el nuevo componente `StaticCountdown` en el marcado.

> [!TIP]
> Si se opta por mostrar el temporizador de cuenta regresiva, solamente se debe restaurar la importación del componente dinámico `Countdown` en [`ParallaxSection.astro`]((diffhunk://#diff-0371bbc79a2e6b24278803b057873e6350143fb86b0313373dbba39c024b2afbL5-R5))

Vista previa:

Móvil:

![image](https://github.com/user-attachments/assets/1347cdab-2670-488a-8d1c-e7d3124b4f2c)

Escritorio:

![image](https://github.com/user-attachments/assets/1c5e73da-e546-4203-9e8f-2025f020a3e0)
